### PR TITLE
Bump werkzeug[watchdog] from 2.0.3 to 2.1.2

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,6 +1,6 @@
 -r base.txt
 
-Werkzeug[watchdog]==2.0.3 # https://github.com/pallets/werkzeug
+Werkzeug[watchdog]==2.1.2 # https://github.com/pallets/werkzeug
 ipdb==0.13.9  # https://github.com/gotcha/ipdb
 psycopg2==2.9.3  # https://github.com/psycopg/psycopg2
 watchgod==0.7  # https://github.com/samuelcolvin/watchgod


### PR DESCRIPTION
Bumps [werkzeug[watchdog]](https://github.com/pallets/werkzeug) from 2.0.3 to 2.1.2.
- [Release notes](https://github.com/pallets/werkzeug/releases)
- [Changelog](https://github.com/pallets/werkzeug/blob/main/CHANGES.rst)
- [Commits](https://github.com/pallets/werkzeug/compare/2.0.3...2.1.2)

---
updated-dependencies:
- dependency-name: werkzeug[watchdog]
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>