### PR TITLE
Bump postgres from 14.1 to 14.3 in /compose/production/postgres

### DIFF
--- a/compose/production/postgres/Dockerfile
+++ b/compose/production/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:14.1
+FROM postgres:14.3
 
 COPY ./compose/production/postgres/maintenance /usr/local/bin/maintenance
 RUN chmod +x /usr/local/bin/maintenance/*


### PR DESCRIPTION
Bumps postgres from 14.1 to 14.3.

---
updated-dependencies:
- dependency-name: postgres
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>