### PR TITLE
Bump traefik from v2.2.11 to v2.7.0 in /compose/production/traefik

### DIFF
--- a/compose/production/traefik/Dockerfile
+++ b/compose/production/traefik/Dockerfile
@@ -1,4 +1,4 @@
-FROM traefik:v2.2.11
+FROM traefik:v2.7.0
 RUN mkdir -p /etc/traefik/acme \
   && touch /etc/traefik/acme/acme.json \
   && chmod 600 /etc/traefik/acme/acme.json


### PR DESCRIPTION
Bumps traefik from v2.2.11 to v2.7.0.

---
updated-dependencies:
- dependency-name: traefik
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>